### PR TITLE
[FIX] fix - validateRequest for RequestType.LAUNCH

### DIFF
--- a/src/main/kotlin/bridge/BridgeGame.kt
+++ b/src/main/kotlin/bridge/BridgeGame.kt
@@ -133,6 +133,8 @@ class BridgeGame {
 
     private fun validateRequest(request: RequestType) {
         if (lastResponsePacket == null) {
+            if(request == RequestType.LAUNCH) return
+
             throw InvalidRequestException(BridgeGameErrorMessages.INVALID_REQUEST_NOT_STARTED.message)
         }
         if (lastResponsePacket!!.popAdditionalMessage() != request) {


### PR DESCRIPTION
### BridgeGame.kt
`validateRequest` 함수가 처음 시작할 때 `RequestType.LAUNCH`까지 예외 처리하는 오류를 수정함